### PR TITLE
Bump dependencies and test with ruby 2.4.0

### DIFF
--- a/sema_api_ruby.gemspec
+++ b/sema_api_ruby.gemspec
@@ -26,13 +26,15 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.9.1'
-  spec.add_dependency 'faraday_middleware', '~> 0.10.0'
-  spec.add_dependency 'fastimage', '~> 1.7.0'
-  
-  spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'pry', '~> 0.10.1'
-  spec.add_development_dependency 'vcr', '~> 2.9.3'
+  spec.add_dependency 'faraday', '~> 0.11.0'
+  spec.add_dependency 'faraday_middleware', '~> 0.11.0'
+  spec.add_dependency 'fastimage', '~> 1.8.1'
 
+  spec.add_development_dependency 'bundler', '~> 1.9'
+  spec.add_development_dependency 'dotenv', '~> 2.1.2'
+  spec.add_development_dependency 'pry', '~> 0.10.1'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.5.0'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
+  spec.add_development_dependency 'webmock', '~> 2.3.2'
 end


### PR DESCRIPTION
- Bump all gems to latest versions
- Add development dependencies preventing `bundle exec rspec`
- test with ruby 2.4.0